### PR TITLE
Update krb5.conf.erb

### DIFF
--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -13,64 +13,15 @@ default_keytab_name = FILE:/etc/krb5.keytab
 
 [realms]
 INTRANET.EPFL.CH = {
-kdc = ad3.intranet.epfl.ch:88
-admin_server = ad3.intranet.epfl.ch:749
+kdc = intranet.epfl.ch:88
+admin_server = intranet.epfl.ch:749
 default_domain = intranet.epfl.ch
-}
-SCX.INTRANET.EPFL.CH = {
-kdc = scxdc0.scx.intranet.epfl.ch:88
-admin_server = scxdc0.scx.intranet.epfl.ch:749
-default_domain = scx.intranet.epfl.ch
-}
-IC.INTRANET.EPFL.CH = {
-kdc = icdc1.ic.intranet.epfl.ch:88
-admin_server = icdc1.ic.intranet.epfl.ch:749
-default_domain = ic.intranet.epfl.ch
-}
-ENAC.INTRANET.EPFL.CH = {
-kdc = enacdc3.enac.intranet.epfl.ch:88
-admin_server = enacdc3.enac.intranet.epfl.ch:749
-default_domain = enac.intranet.epfl.ch
-}
-SB.INTRANET.EPFL.CH = {
-kdc = sbdc1.sb.intranet.epfl.ch:88
-admin_server = sbdc1.sb.intranet.epfl.ch:749
-default_domain = sb.intranet.epfl.ch
-}
-STI.INTRANET.EPFL.CH = {
-kdc = stisrv3.sti.intranet.epfl.ch:88
-admin_server = stisrv3.sti.intranet.epfl.ch:749
-default_domain = sti.intranet.epfl.ch
-}
-
-STUDENTS.INTRANET.EPFL.CH = {
-kdc = studentsdc1.students.intranet.epfl.ch:88
-admin_server = studentsdc1.students.intranet.epfl.ch:749
-default_domain = students.intranet.epfl.ch
-}
-SV.INTRANET.EPFL.CH = {
-kdc = svsrv5.sv.intranet.epfl.ch:88
-admin_server = svsrv5.sv.intranet.epfl.ch:749
-default_domain = sv.intranet.epfl.ch
 }
 
 [domain_realm]
 .intranet.epfl.ch = INTRANET.EPFL.CH
 intranet.epfl.ch = INTRANET.EPFL.CH
-.scx.intranet.epfl.ch = SCX.INTRANET.EPFL.CH
-scx.intranet.epfl.ch = SCX.INTRANET.EPFL.CH
-.ic.intranet.epfl.ch = IC.INTRANET.EPFL.CH
-ic.intranet.epfl.ch = IC.INTRANET.EPFL.CH
-.enac.intranet.epfl.ch = ENAC.INTRANET.EPFL.CH
-enac.intranet.epfl.ch = ENAC.INTRANET.EPFL.CH
-.sb.intranet.epfl.ch = SB.INTRANET.EPFL.CH
-sb.intranet.epfl.ch = SB.INTRANET.EPFL.CH
-.sti.intranet.epfl.ch = STI.INTRANET.EPFL.CH
-sti.intranet.epfl.ch = STI.INTRANET.EPFL.CH
-.students.intranet.epfl.ch = STUDENTS.INTRANET.EPFL.CH
-students.intranet.epfl.ch = STUDENTS.INTRANET.EPFL.CH
-.sv.intranet.epfl.ch = SV.INTRANET.EPFL.CH
-sv.intranet.epfl.ch = SV.INTRANET.EPFL.CH
+
 [appdefaults]
 pam = {
 debug = true
@@ -79,4 +30,3 @@ renew_lifetime = 36000
 forwardable = true
 krb4_convert = false
 }
-


### PR DESCRIPTION
Passage en mode mono-domaine (intranet.epfl.ch). Les sous-domaines [sb,sv,ic,sti,cours,students,scx].intranet.epfl.ch n'existent plus et ont été intégrés dans le domaine principal sous la forme d'unités organisationnelles (OU).