### PR TITLE
Enable manual login on latest ubuntu version

### DIFF
--- a/facts.d/checkLightDM
+++ b/facts.d/checkLightDM
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Check if LightDM is the default DM 
+if grep -q lightdm /etc/X11/default-display-manager; then
+  echo "is_lightdm_active=true"
+else
+  echo "is_lightdm_active=false"
+fi

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,7 +209,6 @@ class epfl_sso(
   #
   case $::osfamily {
     'Debian': {
-      notify {"is light dm the defaut greeter = $::is_lightdm_active":}
       if ($::operatingsystemrelease in ['15.04', '15.10', '16.04', '16.10'] and $::operatingsystem == 'Ubuntu') {
         if ($::is_lightdm_active) {
           file { "/etc/lightdm/lightdm.conf.d" :
@@ -224,7 +223,7 @@ class epfl_sso(
 greeter-show-manual-login=true
 ")
           }~>service { "lightdm" :
-            ensure => running # Restart lightdm if the 50-show-manueal-login.conf file changes
+            ensure => running # Restart lightdm if the 50-show-manual-login.conf file changes
           }
         } else {
           notify {"LightDM is not the default display manager, nothing changed.":}


### PR DESCRIPTION
* New fact `is_lightdm_active` which return true in case of lightdm is the default display manager
* Create the `/etc/lightdm/lightdm.conf.d` folder
* Create the `/etc/lightdm/lightdm.conf.d/50-show-manual-login.conf`