### PR TITLE
issues #30 : Cert URL is not working without SSL

### DIFF
--- a/manifests/private/ad.pp
+++ b/manifests/private/ad.pp
@@ -63,7 +63,7 @@
 class epfl_sso::private::ad(
   $ad_server,
   $join_domain,
-  $epflca_cert_url = 'http://certauth.epfl.ch/epflca.cer',
+  $epflca_cert_url = 'https://certauth.epfl.ch/epflca.cer',
   $renew_domain_credentials = true
 ) inherits epfl_sso::private::params {
   if ($::epfl_krb5_resolved == "false") {


### PR DESCRIPTION
As mention in https://github.com/epfl-sti/puppet.epfl_sso/issues/30 Manifest fails on cert download, certificate URL must be in SSL now.